### PR TITLE
pin pixi to v0.70.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           persist-credentials: false
       - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
+        with:
+          pixi-version: v0.70.2
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: pixi-lock

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@ build:
   jobs:
     create_environment:
       - asdf plugin add pixi
-      - asdf install pixi latest
-      - asdf global pixi latest
+      - asdf install pixi 0.70.2
+      - asdf global pixi 0.70.2
     install:
       - pixi install -e docs
     build:

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ preview = ["pixi-build"]
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 exclude-newer = "5d" # security pre-caution against compromised packages
-requires-pixi = ">=0.67.0"
+requires-pixi = ">=0.67.0,<0.71.0"
 
 [package]
 name = "virtualship"


### PR DESCRIPTION
CI is failing, pin `pixi` to v0.70.2, as in [Parcels/#2701](https://github.com/Parcels-code/Parcels/pull/2701). VirtualShip is currently incompatible with latest version of Pixi (issue to follow, for tracking).