### PR TITLE
Refactor dataset retrieval specs

### DIFF
--- a/src/virtualship/instruments/adcp.py
+++ b/src/virtualship/instruments/adcp.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 import numpy as np
 from parcels import ParticleFile, ParticleSet
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.utils import build_particle_class_from_sensors, register_instrument
@@ -61,9 +61,6 @@ class ADCPInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize ADCPInstrument."""
         variables = expedition.instruments_config.adcp_config.active_variables()
-        fetch_spec = {
-            "spatial": True,
-        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -71,7 +68,7 @@ class ADCPInstrument(Instrument):
             add_bathymetry=False,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            fetch_spec=fetch_spec,
+            fetch_spec=FetchSpec(),
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/adcp.py
+++ b/src/virtualship/instruments/adcp.py
@@ -61,9 +61,9 @@ class ADCPInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize ADCPInstrument."""
         variables = expedition.instruments_config.adcp_config.active_variables()
-        limit_spec = {
-            "spatial": True
-        }  # spatial limits; lat/lon constrained to waypoint locations + buffer
+        fetch_spec = {
+            "spatial": True,
+        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -71,8 +71,7 @@ class ADCPInstrument(Instrument):
             add_bathymetry=False,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            spacetime_buffer_size=None,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/argo_float.py
+++ b/src/virtualship/instruments/argo_float.py
@@ -7,7 +7,7 @@ import numpy as np
 from parcels import ParticleFile, ParticleSet, StatusCode, Variable
 from parcels.kernels import AdvectionRK2
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.models.spacetime import Spacetime
@@ -253,12 +253,11 @@ class ArgoFloatInstrument(Instrument):
             "V": "vo",
             **sensor_variables,
         }  # advection variables (U and V) are always required for argo float simulation; sensor variables come from config
-        fetch_spec = {
-            "spatial": True,
-            "latlon": 3.0,  # [degrees]
-            "time": expedition.instruments_config.argo_float_config.lifetime.total_seconds()
+        fetch_spec = FetchSpec(
+            latlon_buffer=3.0,  # [degrees]
+            time_buffer=expedition.instruments_config.argo_float_config.lifetime.total_seconds()
             / (24 * 3600),  # [days]
-        }
+        )
 
         super().__init__(
             expedition,

--- a/src/virtualship/instruments/argo_float.py
+++ b/src/virtualship/instruments/argo_float.py
@@ -253,13 +253,11 @@ class ArgoFloatInstrument(Instrument):
             "V": "vo",
             **sensor_variables,
         }  # advection variables (U and V) are always required for argo float simulation; sensor variables come from config
-        spacetime_buffer_size = {
+        fetch_spec = {
+            "spatial": True,
             "latlon": 3.0,  # [degrees]
             "time": expedition.instruments_config.argo_float_config.lifetime.total_seconds()
             / (24 * 3600),  # [days]
-        }
-        limit_spec = {
-            "spatial": True,  # spatial limits; lat/lon constrained to waypoint locations + buffer
         }
 
         super().__init__(
@@ -268,8 +266,7 @@ class ArgoFloatInstrument(Instrument):
             add_bathymetry=True,
             allow_time_extrapolation=False,
             verbose_progress=True,
-            spacetime_buffer_size=spacetime_buffer_size,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/base.py
+++ b/src/virtualship/instruments/base.py
@@ -50,8 +50,7 @@ class Instrument(abc.ABC):
         allow_time_extrapolation: bool,
         verbose_progress: bool,
         from_data: Path | None,
-        spacetime_buffer_size: dict | None = None,
-        limit_spec: dict | None = None,
+        fetch_spec: dict | None = None,
     ):
         """Initialise instrument."""
         self.expedition = expedition
@@ -67,8 +66,7 @@ class Instrument(abc.ABC):
         self.add_bathymetry = add_bathymetry
         self.allow_time_extrapolation = allow_time_extrapolation
         self.verbose_progress = verbose_progress
-        self.spacetime_buffer_size = spacetime_buffer_size
-        self.limit_spec = limit_spec
+        self.fetch_spec = fetch_spec
 
         wp_lats, wp_lons = _get_waypoint_latlons(expedition.schedule.waypoints)
         wp_times = [
@@ -153,11 +151,11 @@ class Instrument(abc.ABC):
         )
 
         latlon_buffer = self._get_spec_value(
-            "buffer", "latlon", 0.25
+            "latlon", 0.25
         )  # [degrees]; default 0.25 deg buffer to ensure coverage in field cell edge cases
-        depth_min = self._get_spec_value("limit", "depth_min", None)
-        depth_max = self._get_spec_value("limit", "depth_max", None)
-        spatial_constraint = self._get_spec_value("limit", "spatial", True)
+        depth_min = self._get_spec_value("depth_min", None)
+        depth_max = self._get_spec_value("depth_max", None)
+        spatial_constraint = self._get_spec_value("spatial", True)
 
         min_lon_bound = self.min_lon - latlon_buffer if spatial_constraint else None
         max_lon_bound = self.max_lon + latlon_buffer if spatial_constraint else None
@@ -176,8 +174,6 @@ class Instrument(abc.ABC):
             minimum_depth=depth_min,
             maximum_depth=depth_max,
             coordinates_selection_method="outside",
-            service="arco-geo-series",
-            chunk_size_limit=1,
             vertical_axis="elevation",
         )
 
@@ -190,7 +186,7 @@ class Instrument(abc.ABC):
         fieldsets_list = []
         keys = list(self.variables.keys())
 
-        time_buffer = self._get_spec_value("buffer", "time", 0.0)
+        time_buffer = self._get_spec_value("time", 0.0)
 
         for key in keys:
             var = self.variables[key]
@@ -251,8 +247,3 @@ class Instrument(abc.ABC):
             base_fieldset.add_field(uv)
 
         return base_fieldset
-
-    def _get_spec_value(self, spec_type: str, key: str, default=None):
-        """Helper to extract a value from spacetime_buffer_size or limit_spec."""
-        spec = self.spacetime_buffer_size if spec_type == "buffer" else self.limit_spec
-        return spec.get(key) if spec and spec.get(key) is not None else default

--- a/src/virtualship/instruments/base.py
+++ b/src/virtualship/instruments/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import collections
+from dataclasses import dataclass
 from datetime import timedelta
 from itertools import pairwise
 from pathlib import Path
@@ -28,6 +29,17 @@ if TYPE_CHECKING:
     from virtualship.models import Expedition
 
 
+@dataclass
+class FetchSpec:
+    """Fetch constraints and parameters for dataset retrieval."""
+
+    spatial: bool = True
+    latlon_buffer: float = 0.25  # degrees
+    time_buffer: float = 0.0  # days
+    depth_min: float | None = None
+    depth_max: float | None = None
+
+
 class Instrument(abc.ABC):
     """Base class for instruments and their simulation."""
 
@@ -50,7 +62,7 @@ class Instrument(abc.ABC):
         allow_time_extrapolation: bool,
         verbose_progress: bool,
         from_data: Path | None,
-        fetch_spec: dict | None = None,
+        fetch_spec: FetchSpec | None = None,
     ):
         """Initialise instrument."""
         self.expedition = expedition
@@ -66,7 +78,7 @@ class Instrument(abc.ABC):
         self.add_bathymetry = add_bathymetry
         self.allow_time_extrapolation = allow_time_extrapolation
         self.verbose_progress = verbose_progress
-        self.fetch_spec = fetch_spec
+        self.fetch_spec = fetch_spec or FetchSpec()
 
         wp_lats, wp_lons = _get_waypoint_latlons(expedition.schedule.waypoints)
         wp_times = [
@@ -150,12 +162,10 @@ class Instrument(abc.ABC):
             variable=var if not physical else None,
         )
 
-        latlon_buffer = self._get_spec_value(
-            "latlon", 0.25
-        )  # [degrees]; default 0.25 deg buffer to ensure coverage in field cell edge cases
-        depth_min = self._get_spec_value("depth_min", None)
-        depth_max = self._get_spec_value("depth_max", None)
-        spatial_constraint = self._get_spec_value("spatial", True)
+        latlon_buffer = self.fetch_spec.latlon_buffer
+        depth_min = self.fetch_spec.depth_min
+        depth_max = self.fetch_spec.depth_max
+        spatial_constraint = self.fetch_spec.spatial
 
         min_lon_bound = self.min_lon - latlon_buffer if spatial_constraint else None
         max_lon_bound = self.max_lon + latlon_buffer if spatial_constraint else None
@@ -186,7 +196,7 @@ class Instrument(abc.ABC):
         fieldsets_list = []
         keys = list(self.variables.keys())
 
-        time_buffer = self._get_spec_value("time", 0.0)
+        time_buffer = self.fetch_spec.time_buffer
 
         for key in keys:
             var = self.variables[key]

--- a/src/virtualship/instruments/ctd.py
+++ b/src/virtualship/instruments/ctd.py
@@ -142,9 +142,9 @@ class CTDInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize CTDInstrument."""
         variables = expedition.instruments_config.ctd_config.active_variables()
-        limit_spec = {
-            "spatial": True
-        }  # spatial limits; lat/lon constrained to waypoint locations + buffer
+        fetch_spec = {
+            "spatial": True,
+        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -152,8 +152,7 @@ class CTDInstrument(Instrument):
             add_bathymetry=True,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            spacetime_buffer_size=None,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/ctd.py
+++ b/src/virtualship/instruments/ctd.py
@@ -7,7 +7,7 @@ import numpy as np
 from parcels import ParticleFile, ParticleSet, Variable
 from parcels._core.statuscodes import StatusCode
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.utils import (
@@ -142,9 +142,6 @@ class CTDInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize CTDInstrument."""
         variables = expedition.instruments_config.ctd_config.active_variables()
-        fetch_spec = {
-            "spatial": True,
-        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -152,7 +149,7 @@ class CTDInstrument(Instrument):
             add_bathymetry=True,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            fetch_spec=fetch_spec,
+            fetch_spec=FetchSpec(),
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/drifter.py
+++ b/src/virtualship/instruments/drifter.py
@@ -88,13 +88,13 @@ class DrifterInstrument(Instrument):
             "V": "vo",
             **sensor_variables,
         }  # advection variables (U and V) are always required for drifter simulation; sensor variables come from config
-        spacetime_buffer_size = {
-            "latlon": None,
+        fetch_spec = {
+            "spatial": True,
+            "latlon": 30.0,  # [degrees]; TODO: generous buffer to limit tmp file size download, can potentially be removed in the future as and when Parcels streaming performance improves (see #358)
             "time": expedition.instruments_config.drifter_config.lifetime.total_seconds()
-            / (24 * 3600),  # [days]
-        }
-        limit_spec = {
-            "spatial": False,  # no spatial limits; generate global fieldset
+            / (
+                24 * 3600
+            ),  # [days]; TODO: as above, can potentially be removed in the future
             "depth_min": abs(
                 expedition.instruments_config.drifter_config.depth_meter
             ),  # [meters]
@@ -109,8 +109,7 @@ class DrifterInstrument(Instrument):
             add_bathymetry=False,
             allow_time_extrapolation=False,
             verbose_progress=True,
-            spacetime_buffer_size=spacetime_buffer_size,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/drifter.py
+++ b/src/virtualship/instruments/drifter.py
@@ -8,7 +8,7 @@ from parcels import ParticleFile, ParticleSet, Variable
 from parcels._core.statuscodes import StatusCode
 from parcels.kernels import AdvectionRK2
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.models.spacetime import Spacetime
@@ -88,20 +88,17 @@ class DrifterInstrument(Instrument):
             "V": "vo",
             **sensor_variables,
         }  # advection variables (U and V) are always required for drifter simulation; sensor variables come from config
-        fetch_spec = {
-            "spatial": True,
-            "latlon": 30.0,  # [degrees]; TODO: generous buffer to limit tmp file size download, can potentially be removed in the future as and when Parcels streaming performance improves (see #358)
-            "time": expedition.instruments_config.drifter_config.lifetime.total_seconds()
-            / (
-                24 * 3600
-            ),  # [days]; TODO: as above, can potentially be removed in the future
-            "depth_min": abs(
+        fetch_spec = FetchSpec(
+            latlon_buffer=30.0,  # TODO: generous buffer to limit tmp file size download, can potentially be removed in the future as and when Parcels streaming performance improves (see #358)
+            time_buffer=expedition.instruments_config.drifter_config.lifetime.total_seconds()
+            / (24 * 3600),  # [days]
+            depth_min=abs(
                 expedition.instruments_config.drifter_config.depth_meter
             ),  # [meters]
-            "depth_max": abs(
+            depth_max=abs(
                 expedition.instruments_config.drifter_config.depth_meter
             ),  # [meters]
-        }
+        )
 
         super().__init__(
             expedition,

--- a/src/virtualship/instruments/ship_underwater_st.py
+++ b/src/virtualship/instruments/ship_underwater_st.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 import numpy as np
 from parcels import ParticleFile, ParticleSet
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.utils import (
@@ -67,11 +67,6 @@ class Underwater_STInstrument(Instrument):
         variables = (
             expedition.instruments_config.ship_underwater_st_config.active_variables()
         )
-        fetch_spec = {
-            "spatial": True,
-            "latlon": 0.25,  # [degrees]
-            "time": 0.0,  # [days]
-        }
 
         super().__init__(
             expedition,
@@ -79,7 +74,7 @@ class Underwater_STInstrument(Instrument):
             add_bathymetry=False,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            fetch_spec=fetch_spec,
+            fetch_spec=FetchSpec(),
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/ship_underwater_st.py
+++ b/src/virtualship/instruments/ship_underwater_st.py
@@ -67,13 +67,11 @@ class Underwater_STInstrument(Instrument):
         variables = (
             expedition.instruments_config.ship_underwater_st_config.active_variables()
         )
-        spacetime_buffer_size = {
+        fetch_spec = {
+            "spatial": True,
             "latlon": 0.25,  # [degrees]
             "time": 0.0,  # [days]
         }
-        limit_spec = {
-            "spatial": True
-        }  # spatial limits; lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -81,8 +79,7 @@ class Underwater_STInstrument(Instrument):
             add_bathymetry=False,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            spacetime_buffer_size=spacetime_buffer_size,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/xbt.py
+++ b/src/virtualship/instruments/xbt.py
@@ -7,7 +7,7 @@ import numpy as np
 from parcels import ParticleFile, ParticleSet, Variable
 from parcels._core.statuscodes import StatusCode
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.sensors import SensorType
 from virtualship.instruments.types import InstrumentType
 from virtualship.models.spacetime import Spacetime
@@ -95,9 +95,6 @@ class XBTInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize XBTInstrument."""
         variables = expedition.instruments_config.xbt_config.active_variables()
-        fetch_spec = {
-            "spatial": True,
-        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -105,7 +102,7 @@ class XBTInstrument(Instrument):
             add_bathymetry=True,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            fetch_spec=fetch_spec,
+            fetch_spec=FetchSpec(),
             from_data=from_data,
         )
 

--- a/src/virtualship/instruments/xbt.py
+++ b/src/virtualship/instruments/xbt.py
@@ -95,9 +95,9 @@ class XBTInstrument(Instrument):
     def __init__(self, expedition, from_data):
         """Initialize XBTInstrument."""
         variables = expedition.instruments_config.xbt_config.active_variables()
-        limit_spec = {
-            "spatial": True
-        }  # spatial limits; lat/lon constrained to waypoint locations + buffer
+        fetch_spec = {
+            "spatial": True,
+        }  # lat/lon constrained to waypoint locations + buffer
 
         super().__init__(
             expedition,
@@ -105,8 +105,7 @@ class XBTInstrument(Instrument):
             add_bathymetry=True,
             allow_time_extrapolation=True,
             verbose_progress=False,
-            spacetime_buffer_size=None,
-            limit_spec=limit_spec,
+            fetch_spec=fetch_spec,
             from_data=from_data,
         )
 

--- a/tests/instruments/test_base.py
+++ b/tests/instruments/test_base.py
@@ -2,9 +2,24 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from virtualship.instruments.base import Instrument
+from virtualship.instruments.base import FetchSpec, Instrument
 from virtualship.instruments.types import InstrumentType
 from virtualship.utils import get_instrument_class
+
+
+def test_FetchSpec():
+    fetch_spec = FetchSpec()
+
+    # test that default values are set
+    assert fetch_spec.latlon_buffer is not None
+    assert fetch_spec.time_buffer is not None
+
+    # test setting values (in new instance) and that original is unchanged in memory
+    fetch_spec2 = FetchSpec(latlon_buffer=0.5, time_buffer=1.0)
+    assert fetch_spec2.latlon_buffer == 0.5
+    assert fetch_spec2.time_buffer == 1.0
+
+    assert fetch_spec.latlon_buffer != fetch_spec2.latlon_buffer
 
 
 def test_all_instruments_have_instrument_class():


### PR DESCRIPTION
This PR is a small refactoring for the migrate-v4 branch. The previous `limit_spec` and `spacetime_buffer_size` logic was getting messy and unclear how the two dicts should interact. I find adding a `FetchSpec` dataclass in base.py to be clearer and more explicit about the requirements for `Instrument` classes and clearer about what the defaults are.